### PR TITLE
add webpack HotModuleReplacementPlugin

### DIFF
--- a/config/build/buildDevServer.ts
+++ b/config/build/buildDevServer.ts
@@ -6,5 +6,6 @@ export function buildDevServer(options: BuildOptions): WebpackDevServerConfigura
         port: options.port,
         open: true,
         historyApiFallback: true, // Cannot GET /about
+        hot: true, // for Hot Module Replacement (HMR)
     }
 }

--- a/config/build/buildPlugins.ts
+++ b/config/build/buildPlugins.ts
@@ -19,10 +19,12 @@ export function buildPlugins({ paths, isDev }: BuildOptions): webpack.WebpackPlu
 
     new webpack.DefinePlugin({
         GLOBAL_ISDEV: JSON.stringify(isDev),
-    })
+    }),
 
-        // new webpack.HotModuleReplacementPlugin(),
+    new webpack.HotModuleReplacementPlugin(), // Hot Module Replacement (HMR) - isDev
+        // new ReactRefreshWebpackPlugin(), // An EXPERIMENTAL Webpack plugin to enable "Fast Refresh" 
+        // (also previously known as Hot Reloading) for React components. -  isDev
+
     ]
-
 
 }

--- a/src/app/styles/themes/light.scss
+++ b/src/app/styles/themes/light.scss
@@ -1,5 +1,5 @@
 .app {
-    --bg-color: rgb(107, 105, 105);
+    --bg-color: rgb(202, 233, 135);
     --inverted-bg-color: rgb(79, 75, 75);
 
     --primary-color: rgb(2, 46, 70);

--- a/src/shared/ui/appLink/Button/Button.module.scss
+++ b/src/shared/ui/appLink/Button/Button.module.scss
@@ -1,6 +1,6 @@
 .button {
     cursor: pointer;
-    color: yellow;
+    color: rgb(37, 200, 89);
 ;
 }
 

--- a/src/widgets/LangSwitcher/ui/LangSwitcher.module.scss
+++ b/src/widgets/LangSwitcher/ui/LangSwitcher.module.scss
@@ -1,4 +1,4 @@
 .langswitcher {
-    background: yellow;
+    // background: rgb(61, 37, 200);
     color: var(--inverted-secondary-color);
 }


### PR DESCRIPTION
add webpack HotModuleReplacementPlugin for exchanges, adds, or removes modules while an application is running, without a full reload