### PR TITLE
fix: store mount

### DIFF
--- a/src/app/providers/StoreProvider/config/StateSchema.ts
+++ b/src/app/providers/StoreProvider/config/StateSchema.ts
@@ -41,7 +41,6 @@ export interface ReduxStoreWithManager extends EnhancedStore<StateSchema> {
 
 export interface ThunkExtraArg {
     api: AxiosInstance;
-    navigate?: (to: To, options?: NavigateOptions) => void,
 }
 
 export interface ThunkConfig<T> {

--- a/src/app/providers/StoreProvider/config/store.ts
+++ b/src/app/providers/StoreProvider/config/store.ts
@@ -11,7 +11,6 @@ import { createReducerManager } from './ReducerManager';
 export function createReduxStore(
     initialState?: StateSchema,
     asyncReducers?: ReducersMapObject<StateSchema>,
-    navigate?: (to: To, options?: NavigateOptions) => void,
 ) {
     const rootReducer: ReducersMapObject<StateSchema> = {
         ...asyncReducers,
@@ -26,7 +25,6 @@ export function createReduxStore(
 
     const extraArg: ThunkExtraArg = {
         api: $api,
-        navigate,
     };
 
     const store = configureStore({
@@ -37,7 +35,6 @@ export function createReduxStore(
             thunk: {
                 extraArgument: {
                     api: $api,
-                    navigate,
                 },
             },
         }),

--- a/src/app/providers/StoreProvider/ui/StoreProvider.tsx
+++ b/src/app/providers/StoreProvider/ui/StoreProvider.tsx
@@ -18,13 +18,16 @@ export const StoreProvider = (props: StoreProviderProps) => {
         asyncReducers,
     } = props;
 
-    const navigate = useNavigate();
+    // const navigate = useNavigate();
 
     const store = createReduxStore(
         initialState as StateSchema,
         asyncReducers as ReducersMapObject<StateSchema>,
-        navigate,
+        // navigate,
     );
+
+    // console.log('render'); // каждый раз, когда переходили на другую страницу, создавался новый стор и в провайдер попадал новый стор. Так делать нельзя!!!
+    // поэтому navigate удаляем
 
     return (
         <Provider store={store}>

--- a/src/entities/Article/ui/ArticleViewSelector/ArticleViewSelector.tsx
+++ b/src/entities/Article/ui/ArticleViewSelector/ArticleViewSelector.tsx
@@ -35,6 +35,7 @@ export const ArticleViewSelector = memo((props: ArticleViewSelectorProps) => {
         <div className={classNames(cls.ArticleViewSelector, {}, [className])}>
             {viewTypes.map((viewType) => (
                 <Button
+                    key={viewType.view}
                     theme={ButtonTheme.CLEAR}
                     onClick={onClick(viewType.view)}
                 >

--- a/src/pages/ArticlesPage/model/selectors/articlesPageSelectors.ts
+++ b/src/pages/ArticlesPage/model/selectors/articlesPageSelectors.ts
@@ -8,3 +8,4 @@ export const getArticlesPageView = (state: StateSchema) => state.articlesPage?.v
 export const getArticlesPageNum = (state: StateSchema) => state.articlesPage?.page || 1;
 export const getArticlesPageLimit = (state: StateSchema) => state.articlesPage?.limit || 9;
 export const getArticlesPageHasMore = (state: StateSchema) => state.articlesPage?.hasMore;
+export const getArticlesPageInited = (state: StateSchema) => state.articlesPage?._inited;

--- a/src/pages/ArticlesPage/model/services/fetchNextArticlesPage/fetchNextArticlesPage.test.ts
+++ b/src/pages/ArticlesPage/model/services/fetchNextArticlesPage/fetchNextArticlesPage.test.ts
@@ -1,4 +1,4 @@
-import { TestAsyncThunk } from 'shared/lib/tests/TestAsyncThunk/TestAsyncThunk';
+import { TestAsyncThunk } from '../../../../../shared/lib/tests/TestAsyncThunk/TestAsyncThunk';
 import { fetchNextArticlesPage } from './fetchNextArticlesPage';
 import { fetchArticlesList } from '../fetchArticlesList/fetchArticlesList';
 

--- a/src/pages/ArticlesPage/model/services/initArticlesPage/initArticlesPage.ts
+++ b/src/pages/ArticlesPage/model/services/initArticlesPage/initArticlesPage.ts
@@ -1,0 +1,25 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import { ArticleView } from '../../../../../entities/Article';
+import { ThunkConfig } from '../../../../../app/providers/StoreProvider';
+import { getArticlesPageInited } from '../../selectors/articlesPageSelectors';
+import { articlesPageActions } from '../../slices/articlesPageSlice';
+import { fetchArticlesList } from '../fetchArticlesList/fetchArticlesList';
+
+export const initArticlesPage = createAsyncThunk<
+    void,
+    ArticleView,
+    ThunkConfig<string>
+    >(
+        'articlesPage/initArticlesPage',
+        async (view, thunkApi) => {
+            const { getState, dispatch } = thunkApi;
+            const inited = getArticlesPageInited(getState());
+
+            if (!inited) {
+                dispatch(articlesPageActions.initState(view)); // сначала инициализируем значения лимита, и только потом подгружаем
+                dispatch(fetchArticlesList({
+                    page: 1,
+                }));
+            }
+        },
+    );

--- a/src/pages/ArticlesPage/model/slices/articlesPageSlice.ts
+++ b/src/pages/ArticlesPage/model/slices/articlesPageSlice.ts
@@ -24,6 +24,7 @@ const articlesPageSlice = createSlice({
         view: ArticleView.GRID,
         page: 1,
         hasMore: true,
+        _inited: false,
     }),
     reducers: {
         setView: (state, action: PayloadAction<ArticleView>) => {
@@ -36,6 +37,7 @@ const articlesPageSlice = createSlice({
         initState: (state, action: PayloadAction<ArticleView>) => {
             state.view = action.payload;
             state.limit = (state.view === ArticleView.GRID ? ArticleLimit.GRID_LIMIT : ArticleLimit.LIST_LIMIT);
+            state._inited = true;
         },
     },
     extraReducers: (builder) => {

--- a/src/pages/ArticlesPage/model/types/articlesPageSchema.ts
+++ b/src/pages/ArticlesPage/model/types/articlesPageSchema.ts
@@ -11,4 +11,6 @@ export interface ArticlesPageSchema extends EntityState<Article> {
     page: number;
     limit?: number;
     hasMore: boolean;
+
+    _inited: boolean; // _ означает, что меняется единожды при инициализации, вручную менять нельзя
 }

--- a/src/pages/ArticlesPage/ui/ArticlesPage/ArticlesPage.tsx
+++ b/src/pages/ArticlesPage/ui/ArticlesPage/ArticlesPage.tsx
@@ -1,6 +1,8 @@
 import { memo, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useSelector } from 'react-redux';
+import { initArticlesPage } from '../../../../pages/ArticlesPage/model/services/initArticlesPage/initArticlesPage';
+import { useInitialEffect } from '../../../../shared/lib/hooks/useInitialEffect/useInitialEffect';
 import { fetchNextArticlesPage } from '../../../../pages/ArticlesPage/model/services/fetchNextArticlesPage/fetchNextArticlesPage';
 import { DynamicModuleLoader, ReducersList } from '../../../../shared/lib/components/DynamicModuleLoader/DynamicModuleLoader';
 import { articlesPageActions, articlesPageReducer, getArticles } from '../../../../pages/ArticlesPage/model/slices/articlesPageSlice';
@@ -9,13 +11,12 @@ import {
 } from '../../../../entities/Article';
 import { classNames } from '../../../../shared/lib/classNames/classNames';
 import clss from './ArticlesPage.module.scss';
-import { fetchArticlesList } from '../../../../pages/ArticlesPage/model/services/fetchArticlesList/fetchArticlesList';
 import {
     getArticlesPageError, getArticlesPageIsLoading, getArticlesPageView,
 } from '../../../../pages/ArticlesPage/model/selectors/articlesPageSelectors';
 import { useAppDispatch } from '../../../../shared/lib/hooks/useAppDispatch/useAppDispatch';
-import { ARTICLES_VIEW_LOCALSTORAGE_KEY } from '../../../../shared/const/localstorage';
 import { Page } from '../../../../shared/ui/Page/Page';
+import { ARTICLES_VIEW_LOCALSTORAGE_KEY } from '../../../../shared/const/localstorage';
 
 interface ArticlesPageProps {
    className?: string;
@@ -41,10 +42,7 @@ const ArticlesPage = (props: ArticlesPageProps) => {
     useEffect(() => {
         if (__PROJECT__ !== 'storybook') {
             const view = localStorage.getItem(ARTICLES_VIEW_LOCALSTORAGE_KEY) as ArticleView;
-            dispatch(articlesPageActions.initState(view)); // сначала инициализируем значения лимита, и только потом подгружаем
-            dispatch(fetchArticlesList({
-                page: 1,
-            }));
+            dispatch(initArticlesPage(view));
         }
     }, [dispatch, view]);
 
@@ -65,7 +63,7 @@ const ArticlesPage = (props: ArticlesPageProps) => {
     }
 
     return (
-        <DynamicModuleLoader reducers={reducers}>
+        <DynamicModuleLoader reducers={reducers} removeAfterUnmount={false}>
             <Page onScrollEnd={onLoadNextPart} className={classNames(clss.articlesPage, {}, [className])}>
                 <ArticleViewSelector view={view} onViewClick={onChangeView} />
                 <ArticleList

--- a/src/shared/lib/components/DynamicModuleLoader/DynamicModuleLoader.tsx
+++ b/src/shared/lib/components/DynamicModuleLoader/DynamicModuleLoader.tsx
@@ -24,9 +24,16 @@ export const DynamicModuleLoader: FC<DynamicModuleLoaderProps> = (props) => {
     const store = useStore() as ReduxStoreWithManager; // получаем наш стор
 
     useEffect(() => {
+        const mountedReducers = store.reducerManager.getReducerMap();
+
         Object.entries(reducers).forEach(([name, reducer]) => {
-            store.reducerManager.add(name as StateSchemaKey, reducer);
-            dispatch({ type: `@INIT ${name} reducer` });
+            const mounted = mountedReducers[name as StateSchemaKey];
+
+            // Добавляем новый редюсер только если его нет
+            if (!mounted) {
+                store.reducerManager.add(name as StateSchemaKey, reducer);
+                dispatch({ type: `@INIT ${name} reducer` });
+            }
         });
 
         return () => {


### PR DESCRIPTION
1. Убрали navigate из StoreProvider, потому что он триггерил перерисовки и у нас создавался новый стор
2. Перенесли логику с ArticlesPage в initArticlesPage
3. Пофиксили в DynamicModuleLoader то, что при переходе с просмотра деталей статьи на список статей заново инициализировался редьюсер  articlesPageSlice/initState, даже если он уже был проинициализирован
