### PR TITLE
add: analyze only for prod

### DIFF
--- a/config/build/buildPlugins.ts
+++ b/config/build/buildPlugins.ts
@@ -4,10 +4,11 @@ import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import CopyPlugin from 'copy-webpack-plugin';
+import { analyze } from 'eslint-scope';
 import { BuildOptions } from './types/config';
 
 export function buildPlugins({
-    paths, isDev, apiUrl, project,
+    paths, isDev, apiUrl, project, analyze,
 }: BuildOptions): webpack.WebpackPluginInstance[] {
     const plugins = [
         new HtmlWebpackPlugin({
@@ -33,9 +34,9 @@ export function buildPlugins({
         }),
     ];
 
-    // plugins.push(new BundleAnalyzerPlugin({
-    //     openAnalyzer: true,
-    // }));
+    plugins.push(new BundleAnalyzerPlugin({
+        analyzerMode: analyze ? 'server' : 'disabled',
+    }));
     // // для проверки bundle
     // // при pre commit обязательно убираем из прод
 
@@ -43,9 +44,6 @@ export function buildPlugins({
         plugins.push(new ReactRefreshWebpackPlugin()); // An EXPERIMENTAL Webpack plugin to enable "Fast Refresh"
         // (also previously known as Hot Reloading) for React components. -  isDev
         plugins.push(new webpack.HotModuleReplacementPlugin()); // Hot Module Replacement (HMR) - isDev
-        plugins.push(new BundleAnalyzerPlugin({
-            openAnalyzer: false,
-        }));
     }
 
     return plugins;

--- a/config/build/types/config.ts
+++ b/config/build/types/config.ts
@@ -22,4 +22,5 @@ export interface BuildOptions {
     port: number;
     apiUrl: string;
     project: 'storybook' | 'frontend' | 'jest';
+    analyze: boolean;
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "storybook": "start-storybook -p 6006 -c ./config/storybook",
     "storybook:build": "build-storybook -c ./config/storybook",
     "prepare": "husky",
-    "generate:FSD-slice": "node ./scripts/createSlice/index.js"
+    "generate:FSD-slice": "node ./scripts/createSlice/index.js",
+    "analyze:build:prod": "webpack  --env mode=production analyze=true apiUrl=https://production-project-server-ten-livid.vercel.app"
   },
   "keywords": [],
   "author": "",

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -26,6 +26,7 @@ export default (env: BuildEnv) => {
         port: PORT,
         apiUrl,
         project: 'frontend',
+        analyze: false,
     });
 
     return config;


### PR DESCRIPTION
1. Добавили команду  "analyze:build:prod" в package.json для анализа бандла в продакшене
