### PR TITLE
fix: add checking for deleting data-testid only for prod in buildBabelLoader

### DIFF
--- a/config/build/loaders/buildBabelLoader.ts
+++ b/config/build/loaders/buildBabelLoader.ts
@@ -28,7 +28,7 @@ export function buildBabelLoader({ isDev, isTsx }: BuildBabelLoaderProps) {
                         },
                     ],
                     '@babel/plugin-transform-runtime',
-                    isTsx && [
+                    isTsx && !isDev && [
                         babelRemovePropsPlugin,
                         {
                             props: ['data-testid'],


### PR DESCRIPTION
1. Пофиксили удаление атрибута data-testid только для режима prod в buildBabelLoader, добавив условие !isDev

