### PR TITLE
refactor: improve build

### DIFF
--- a/config/build/buildPlugins.ts
+++ b/config/build/buildPlugins.ts
@@ -12,15 +12,13 @@ import { BuildOptions } from './types/config';
 export function buildPlugins({
     paths, isDev, apiUrl, project, analyze,
 }: BuildOptions): webpack.WebpackPluginInstance[] {
+    const isProd = !isDev;
+
     const plugins = [
         new HtmlWebpackPlugin({
             template: paths.html,
         }),
         new webpack.ProgressPlugin(),
-        new MiniCssExtractPlugin({
-            filename: 'css/[name].[contenthash:8].css',
-            chunkFilename: 'css/[name].[contenthash:8].css', // когда будем файлы разбивать на асинхронные
-        }),
 
         new webpack.DefinePlugin({
             GLOBAL_ISDEV: JSON.stringify(isDev),
@@ -29,11 +27,7 @@ export function buildPlugins({
             // This makes it possible for us to safely use env vars on our code
             // 'process.env.ASSET_PATH': JSON.stringify(ASSET_PATH),
         }),
-        new CopyPlugin({
-            patterns: [
-                { from: paths.locales, to: paths.buildLocales },
-            ],
-        }),
+
         new ForkTsCheckerWebpackPlugin({
             typescript: {
                 diagnosticOptions: {
@@ -59,6 +53,19 @@ export function buildPlugins({
         plugins.push(new CircularDependencyPlugin({
             exclude: /node_modules/,
             failOnError: true,
+        }));
+    }
+
+    if (isProd) {
+        plugins.push(new MiniCssExtractPlugin({
+            filename: 'css/[name].[contenthash:8].css',
+            chunkFilename: 'css/[name].[contenthash:8].css', // когда будем файлы разбивать на асинхронные
+        }));
+
+        plugins.push(new CopyPlugin({
+            patterns: [
+                { from: paths.locales, to: paths.buildLocales },
+            ],
         }));
     }
 

--- a/config/build/buildWebpackConfig.ts
+++ b/config/build/buildWebpackConfig.ts
@@ -24,7 +24,8 @@ export function buildWebpackConfig(options: BuildOptions): webpack.Configuration
             rules: buildLoaders(options),
         },
         resolve: buildResolvers(options),
-        devtool: isDev ? 'inline-source-map' : undefined,
+        devtool: isDev ? 'eval-cheap-module-source-map' : undefined, // заменили 'inline-source-map' на 'eval-cheap-module-source-map',
+        // которые не так сильно нагружают сборку в dev режиме
         devServer: isDev ? buildDevServer(options) : undefined,
     };
 }

--- a/config/build/loaders/buildBabelLoader.ts
+++ b/config/build/loaders/buildBabelLoader.ts
@@ -12,6 +12,7 @@ export function buildBabelLoader({ isDev, isTsx }: BuildBabelLoaderProps) {
         use: {
             loader: 'babel-loader',
             options: {
+                cacheDirectory: true,
                 presets: ['@babel/preset-env'],
                 plugins: [
                     // [

--- a/config/build/loaders/buildCssLoader.ts
+++ b/config/build/loaders/buildCssLoader.ts
@@ -3,6 +3,7 @@ import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 export function buildCssLoader(isDev: boolean) {
     return {
         test: /\.s[ac]ss$/i,
+        exclude: /node_modules/,
         use: [
             isDev ? 'style-loader' : MiniCssExtractPlugin.loader,
             // MiniCssExtractPlugin.loader вместо "style-loader",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "storybook:build": "build-storybook -c ./config/storybook",
     "prepare": "husky",
     "generate:FSD-slice": "node ./scripts/createSlice/index.js",
-    "analyze:build:prod": "webpack  --env mode=production analyze=true apiUrl=https://production-project-server-ten-livid.vercel.app"
+    "analyze:build:prod": "webpack  --env mode=production analyze=true apiUrl=https://production-project-server-ten-livid.vercel.app",
+    "postinstall": "rimraf ./node_modules/.cache"
   },
   "keywords": [],
   "author": "",

--- a/scripts/clear-cache.js
+++ b/scripts/clear-cache.js
@@ -1,0 +1,12 @@
+// path/fs
+console.log('CLEAR CACHE');
+
+const fs = require('fs');
+const { join: joinPath } = require('path');
+
+const cacheDir = joinPath(__dirname, '..', 'node_modules/.cache');
+fs.rmSync(cacheDir, { recursive: true, force: true });
+
+// rimraf ./node_modules/.cache
+
+// "postinstall": "node ./scripts/clear-cache.js"

--- a/src/.browserslistrc
+++ b/src/.browserslistrc
@@ -1,3 +1,10 @@
 # Browsers that we support
+[production]
 defaults
 not IE 11
+
+
+[development]
+last 2 Chrome versions
+last 2 Firefox versions
+last 1 Safari version


### PR DESCRIPTION
1. Исправили в buildWebpackConfig  devtool: isDev ? 'eval-cheap-module-source-map' : undefined, // заменили 'inline-source-map' на 'eval-cheap-module-source-map',        // которые не так сильно нагружают сборку в dev режиме
2. Разделили плагины в buildPlugins  на dev и prod режимы
3. Добавили в buildCssLoader exclude: /node_modules/
4. Скорректировали .browserslistrc для dev и prod режимов
5. Добавили cacheDirectory:true в buildBabelLoader для кэширования преобразований в файловой системе

